### PR TITLE
remoção de avisos de compilação

### DIFF
--- a/etapa1/hoc1.y
+++ b/etapa1/hoc1.y
@@ -1,5 +1,12 @@
 %{
+#include <stdio.h>
+#include <ctype.h>
+
 #define	YYSTYPE double  /* tipo da pilha de yacc */
+
+int yylex(void);
+void warning(char *, char *);
+void yyerror(char *);
 %}
 %token	NUMBER
 %left	'+' '-'  /* associatividade esquerda */
@@ -19,8 +26,6 @@ expr:	  NUMBER { $$ = $1; }
 %%
 	/* end of grammar */
 
-#include <stdio.h>
-#include <ctype.h>
 char	*progname;		/* para mensagens de erro */
 int	lineno = 1;
 
@@ -31,7 +36,7 @@ main(int argc, char* argv[])	/* hoc1 */
 	yyparse();
 }
 
-yylex(void)			/* hoc1 */
+int yylex(void)			/* hoc1 */
 {
 	int c;
 


### PR DESCRIPTION
A versão anterior do código gerava avisos de compilação devido
à declaração implícita de funções.

A solução de alguns, como printf, consiste em mover os includes para
o início do arquivo, antes da chamada a printf.

Os outros errors consistem em declarar as funções específicas do código
(`yylex`, `warning` e `yyerror`) antes de seu uso. Assim, o compilador
sabe que tipos esperar quando encontrar chamadas para as referidas
funções.

Com as mudanças, vemos que o código compila sem avisos ou erros:

    $ make hoc1
    yacc  hoc1.y
    mv -f y.tab.c hoc1.c
    cc    -c -o hoc1.o hoc1.c
    cc   hoc1.o   -o hoc1
    rm hoc1.o hoc1.c

    $ gcc --version
    gcc (GCC) 8.2.1 20181127
    Copyright (C) 2018 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.